### PR TITLE
실시간 채팅 재연결 시 id 중복 반환 버그 수정

### DIFF
--- a/src/main/java/com/mfc/chatting/chat/application/ChatService.java
+++ b/src/main/java/com/mfc/chatting/chat/application/ChatService.java
@@ -11,7 +11,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface ChatService {
-	Flux<Message> getChatByStream(String roomId, String uuid);
+	Flux<Message> getChatByStream(String roomId, String uuid, String msgId);
 	Flux<Message> getChatByPage(String roomId, String uuid, Pageable page);
 
 	Mono<Message> sendChat(ChatReqDto dto, String uuid);

--- a/src/main/java/com/mfc/chatting/chat/infrastructure/ChatRepository.java
+++ b/src/main/java/com/mfc/chatting/chat/infrastructure/ChatRepository.java
@@ -1,6 +1,7 @@
 package com.mfc.chatting.chat.infrastructure;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +12,7 @@ import org.springframework.data.mongodb.repository.Tailable;
 import com.mfc.chatting.chat.domain.Message;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public interface ChatRepository extends ReactiveMongoRepository<Message, String> {
 	@Tailable
@@ -19,4 +21,7 @@ public interface ChatRepository extends ReactiveMongoRepository<Message, String>
 
 	@Query("{ 'roomId' : ?0, 'createdAt': { $lte: ?1 } }")
 	Flux<Message> findByRoomIdAndCreatedAtBefore(String roomId, Instant createdAt,Pageable page);
+
+	@Query("{ 'roomId': ?0, '_id': ?1 }")
+	Mono<Message> findByRoomIdAndId(String roomId, String msgId);
 }

--- a/src/main/java/com/mfc/chatting/chat/presentation/ChatController.java
+++ b/src/main/java/com/mfc/chatting/chat/presentation/ChatController.java
@@ -40,8 +40,9 @@ public class ChatController {
 	@Operation(summary = "실시간 채팅 조회 API", description = "채팅방 번호에 따른 채팅 목록 조회 (동작 안함 ㅎㅎ..)")
 	public Flux<Message> getChatByStream(
 			@PathVariable(value ="roomId") String roomId,
-			@RequestHeader(value = "UUID", defaultValue = "") String uuid){
-		return chatService.getChatByStream(roomId, uuid)
+			@RequestHeader(value = "UUID", defaultValue = "") String uuid,
+			@RequestParam(value = "msgId", required = false) String msgId){
+		return chatService.getChatByStream(roomId, uuid, msgId)
 				.subscribeOn(Schedulers.boundedElastic());
 	}
 

--- a/src/main/java/com/mfc/chatting/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mfc/chatting/common/response/BaseResponseStatus.java
@@ -15,7 +15,8 @@ public enum BaseResponseStatus {
 	 **/
 	SUCCESS(HttpStatus.OK, true, 200, "요청에 성공했습니다."),
 	CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 채팅방입니다."),
-	INVALID_EXIT(HttpStatus.BAD_REQUEST, false, 400, "잘못된 접근입니다.");
+	INVALID_EXIT(HttpStatus.BAD_REQUEST, false, 400, "잘못된 접근입니다."),
+	CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 채팅입니다.");
 
 	private final HttpStatusCode httpStatusCode;
 	private final boolean isSuccess;


### PR DESCRIPTION
## 📣 실시간 채팅 재연결 시 id 중복 반환 버그 수정
### 📅 2024.06.21
 
 ### 🌵Branch
`feature/fix-strema`  → `develop`

### 📢 Description
- 실시간 채팅 조회 로직 수정 : 재연결 시 `msgId`를 받아서 해당 메세지 이후의 메세지만 반환

### 💬Issue Number
close #18 

### 🛠️Type
- [ ] 새로운 기능 추가 
- [x] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [ ] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [ ] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist 
PR이 다음 요구 사항을 충족하는지 확인하세요. 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note