### PR TITLE
채팅 페이징 조회 시 마지막 페이지 여부 추가

### DIFF
--- a/src/main/java/com/mfc/chatting/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/mfc/chatting/chat/application/ChatRoomServiceImpl.java
@@ -10,13 +10,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.mfc.chatting.chat.domain.ChatRoom;
 import com.mfc.chatting.chat.domain.Member;
-import com.mfc.chatting.chat.domain.Message;
 import com.mfc.chatting.chat.dto.resp.ChatRoomRespDto;
-import com.mfc.chatting.chat.infrastructure.ChatRepository;
 import com.mfc.chatting.chat.infrastructure.ChatRoomRepository;
 import com.mfc.chatting.chat.vo.req.ChatRoomVo;
 import com.mfc.chatting.common.exception.BaseException;
-import com.mfc.chatting.common.response.BaseResponseStatus;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/mfc/chatting/chat/application/ChatService.java
+++ b/src/main/java/com/mfc/chatting/chat/application/ChatService.java
@@ -6,13 +6,14 @@ import org.springframework.data.domain.Pageable;
 
 import com.mfc.chatting.chat.domain.Message;
 import com.mfc.chatting.chat.dto.req.ChatReqDto;
+import com.mfc.chatting.chat.dto.resp.ChatPageRespDto;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface ChatService {
 	Flux<Message> getChatByStream(String roomId, String uuid, Instant now);
-	Flux<Message> getChatByPage(String roomId, String uuid, Pageable page);
+	ChatPageRespDto getChatByPage(String roomId, String uuid, Pageable page);
 
 	Mono<Message> sendChat(ChatReqDto dto, String uuid);
 }

--- a/src/main/java/com/mfc/chatting/chat/application/KafkaConsumer.java
+++ b/src/main/java/com/mfc/chatting/chat/application/KafkaConsumer.java
@@ -8,7 +8,7 @@ import com.mfc.chatting.chat.domain.ChatRoom;
 import com.mfc.chatting.chat.domain.Member;
 import com.mfc.chatting.chat.domain.Message;
 import com.mfc.chatting.chat.dto.kafka.CreateChatRoomDto;
-import com.mfc.chatting.chat.infrastructure.ChatRepository;
+import com.mfc.chatting.chat.infrastructure.ChatReactiveRepository;
 import com.mfc.chatting.chat.infrastructure.ChatRoomRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class KafkaConsumer {
 	private final ChatRoomRepository chatRoomRepository;
-	private final ChatRepository chatRepository;
+	private final ChatReactiveRepository chatReactiveRepository;
 
 	@KafkaListener(topics = "create-chatroom", containerFactory = "createChatRoomListener")
 	public void createChatRoom(CreateChatRoomDto dto) {
@@ -29,7 +29,7 @@ public class KafkaConsumer {
 						.toList())
 				.build());
 
-		chatRepository.save(Message.builder()
+		chatReactiveRepository.save(Message.builder()
 				.type("system")
 				.msg("Chat Room Open")
 				.sender("system")

--- a/src/main/java/com/mfc/chatting/chat/dto/resp/ChatPageRespDto.java
+++ b/src/main/java/com/mfc/chatting/chat/dto/resp/ChatPageRespDto.java
@@ -1,0 +1,15 @@
+package com.mfc.chatting.chat.dto.resp;
+
+import java.util.List;
+
+import com.mfc.chatting.chat.domain.Message;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatPageRespDto {
+	private List<Message> chats;
+	private boolean last;
+}

--- a/src/main/java/com/mfc/chatting/chat/infrastructure/ChatReactiveRepository.java
+++ b/src/main/java/com/mfc/chatting/chat/infrastructure/ChatReactiveRepository.java
@@ -1,0 +1,25 @@
+package com.mfc.chatting.chat.infrastructure;
+
+import java.time.Instant;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import org.springframework.data.mongodb.repository.Tailable;
+
+import com.mfc.chatting.chat.domain.Message;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface ChatReactiveRepository extends ReactiveMongoRepository<Message, String> {
+	@Tailable
+	@Query("{ 'roomId' : ?0, 'createdAt': { $gt: ?1 }}")
+	Flux<Message> findChatByRoomId(String roomId, Instant createdAt);
+
+	@Query("{ 'roomId' : ?0, 'createdAt': { $lte: ?1 } }")
+	Flux<Message> findByRoomIdAndCreatedAtBefore(String roomId, Instant createdAt,Pageable page);
+
+	@Query("{ 'roomId': ?0, '_id': ?1 }")
+	Mono<Message> findByRoomIdAndId(String roomId, String msgId);
+}

--- a/src/main/java/com/mfc/chatting/chat/infrastructure/ChatRepository.java
+++ b/src/main/java/com/mfc/chatting/chat/infrastructure/ChatRepository.java
@@ -1,27 +1,15 @@
 package com.mfc.chatting.chat.infrastructure;
 
 import java.time.Instant;
-import java.util.Optional;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
-import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
-import org.springframework.data.mongodb.repository.Tailable;
 
 import com.mfc.chatting.chat.domain.Message;
 
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-
-public interface ChatRepository extends ReactiveMongoRepository<Message, String> {
-	@Tailable
-	@Query("{ 'roomId' : ?0, 'createdAt': { $gt: ?1 }}")
-	Flux<Message> findChatByRoomId(String roomId, Instant createdAt);
-
+public interface ChatRepository extends MongoRepository<Message, String> {
 	@Query("{ 'roomId' : ?0, 'createdAt': { $lte: ?1 } }")
-	Flux<Message> findByRoomIdAndCreatedAtBefore(String roomId, Instant createdAt,Pageable page);
-
-	@Query("{ 'roomId': ?0, '_id': ?1 }")
-	Mono<Message> findByRoomIdAndId(String roomId, String msgId);
+	Slice<Message> findByRoomIdAndCreatedAtBefore(String roomId, Instant createdAt, Pageable page);
 }

--- a/src/main/java/com/mfc/chatting/chat/presentation/ChatController.java
+++ b/src/main/java/com/mfc/chatting/chat/presentation/ChatController.java
@@ -2,6 +2,7 @@ package com.mfc.chatting.chat.presentation;
 
 import java.time.Instant;
 
+import org.apache.kafka.streams.kstream.internals.graph.BaseRepartitionNode;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -20,6 +21,9 @@ import com.mfc.chatting.chat.application.ChatService;
 import com.mfc.chatting.chat.domain.Message;
 import com.mfc.chatting.chat.dto.req.ChatReqDto;
 import com.mfc.chatting.chat.vo.req.ChatReqVo;
+import com.mfc.chatting.chat.vo.resp.ChatPageRespVo;
+import com.mfc.chatting.common.response.BaseResponse;
+import com.mfc.chatting.common.response.BaseResponseStatus;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -46,11 +50,12 @@ public class ChatController {
 
 	@GetMapping("/page/{roomId}")
 	@Operation(summary = "페이징 채팅 조회 API", description = "채팅방 번호에 따른 채팅 목록 조회")
-	public Flux<Message> getChatByPage(
+	public BaseResponse<ChatPageRespVo> getChatByPage(
 			@PathVariable String roomId,
 			@RequestHeader(value = "UUID", defaultValue = "") String uuid,
 			@PageableDefault(size = 3, sort = "createdAt", direction = Sort.Direction.DESC) Pageable page) {
-		return chatService.getChatByPage(roomId, uuid, page);
+		return new BaseResponse<>(modelMapper.map(
+				chatService.getChatByPage(roomId, uuid, page), ChatPageRespVo.class));
 	}
 
 	@PostMapping

--- a/src/main/java/com/mfc/chatting/chat/vo/resp/ChatPageRespVo.java
+++ b/src/main/java/com/mfc/chatting/chat/vo/resp/ChatPageRespVo.java
@@ -1,0 +1,13 @@
+package com.mfc.chatting.chat.vo.resp;
+
+import java.util.List;
+
+import com.mfc.chatting.chat.domain.Message;
+
+import lombok.Getter;
+
+@Getter
+public class ChatPageRespVo {
+	private List<Message> chats;
+	private boolean last;
+}


### PR DESCRIPTION
## 📣 채팅 페이징 조회 시 마지막 페이지 여부 추가
### 📅 2024.06.23
 
 ### 🌵Branch
`feature/page` → `develop`

### 📢 Description
- `ChatRepository` → `ChatReactiveRepository` 변경 (`MongoReactiveRepository`)
- `ChatRepository` 생성 (`MongoReposiotry`)
- 채팅 페이징 조회 시 반환 형태 변경 : `Flux` → `BaseResponse`
  - 반환값에 마지막 페이지 여부 `last` 추가 

### 💬Issue Number
close #24 

### 🛠️Type
- [ ] 새로운 기능 추가 
- [ ] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [x] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [x] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist 
PR이 다음 요구 사항을 충족하는지 확인하세요. 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note